### PR TITLE
Correct the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Install
 -------
 * Install to python site-packages folder
 ```
-pip install git+https://github.com/pyscf/naive_hci
+pip install git+git://github.com/pyscf/naive-hci
 ```
 
 * Install in a custom folder for development
 ```
-git clone https://github.com/pyscf/naive_hci /home/abc/local/path
+git clone https://github.com/pyscf/naive-hci /home/abc/local/path
 
 # Set pyscf extended module path
 echo 'export PYSCF_EXT_PATH=/home/abc/local/path:$PYSCF_EXT_PATH' >> ~/.bashrc


### PR DESCRIPTION
They were using underscore when they should use '-'. Also the https:// requires one to log into github, whereas using git+git avoids this. 